### PR TITLE
Set Pjax Version header if available

### DIFF
--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -10,6 +10,13 @@ use Symfony\Component\DomCrawler\Crawler;
 class FilterIfPjax
 {
     /**
+     * The DomCrawler instance.
+     * 
+     * @var \Symfony\Component\DomCrawler\Crawler
+     */
+    protected $crawler;
+
+    /**
      * Handle an incoming request.
      *
      * @param \Illuminate\Http\Request $request
@@ -118,6 +125,6 @@ class FilterIfPjax
             return $this->crawler;
         }
 
-        return new Crawler($response->getContent());
+        return $this->crawler = new Crawler($response->getContent());
     }
 }

--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -26,7 +26,8 @@ class FilterIfPjax
         }
 
         $this->filterResponse($response, $request->header('X-PJAX-CONTAINER'))
-            ->setUriHeader($response, $request);
+            ->setUriHeader($response, $request)
+            ->setVersionHeader($response, $request);
 
         return $response;
     }
@@ -39,7 +40,7 @@ class FilterIfPjax
      */
     protected function filterResponse(Response $response, $container)
     {
-        $crawler = new Crawler($response->getContent());
+        $crawler = $this->getCrawler($response);
 
         $response->setContent(
             $this->makeTitle($crawler).
@@ -85,5 +86,38 @@ class FilterIfPjax
     protected function setUriHeader(Response $response, Request $request)
     {
         $response->header('X-PJAX-URL', $request->getRequestUri());
+
+        return $this;
+    }
+
+    /**
+     * @param \Illuminate\Http\Response $response
+     * @param \Illuminate\Http\Request  $request
+     */
+    protected function setVersionHeader(Response $response, Request $request)
+    {
+        $crawler = $this->getCrawler($response);
+        $node = $crawler->filter('head > meta[http-equiv]');
+
+        if ($node->count()) {
+            $response->header('X-PJAX-VERSION', $node->attr('content'));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the DomCrawler instance.
+     *
+     * @param \Illuminate\Http\Response $response
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    protected function getCrawler(Response $response)
+    {
+        if ($this->crawler) {
+            return $this->crawler;
+        }
+
+        return new Crawler($response->getContent());
     }
 }

--- a/tests/FilterIfPjaxTest.php
+++ b/tests/FilterIfPjaxTest.php
@@ -61,6 +61,18 @@ class FilterIfPjaxTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/test', $response->headers->get('X-PJAX-URL'));
     }
 
+    /**
+     * @test
+     */
+    public function it_will_set_the_request_version_header_for_a_pjax_request()
+    {
+        $request = $this->addPjaxHeaders(Request::create('/test'));
+
+        $response = $this->middleware->handle($request, $this->next);
+
+        $this->assertEquals('1.0.0', $response->headers->get('X-PJAX-VERSION'));
+    }
+
     protected function isPjaxReponse(Response $response)
     {
         return $response->headers->has('X-PJAX-URL');

--- a/tests/fixtures/page.html
+++ b/tests/fixtures/page.html
@@ -2,6 +2,7 @@
 
     <head>
         <title>Pjax title</title>
+        <meta http-equiv="x-pjax-version" content="1.0.0">
     </head>
 
     <body>


### PR DESCRIPTION
Sets the Pjax Version header (`X_PJAX_VERSION`) when the `<meta http-equiv="x-pjax-version">` meta tag is found.