### PR TITLE
Fix header name

### DIFF
--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -32,7 +32,7 @@ class FilterIfPjax
             return $response;
         }
 
-        $this->filterResponse($response, $request->header('X-PJAX-CONTAINER'))
+        $this->filterResponse($response, $request->header('X-PJAX-Container'))
             ->setUriHeader($response, $request)
             ->setVersionHeader($response, $request);
 


### PR DESCRIPTION
$request->header('X-PJAX-CONTAINER') return null. Header key case insensitive. work in my local machine greate but i setup on server ( PHP 7.0.2-1+deb.sury.org~trusty+1 ) can't grab container name.

![screenshots](https://cloud.githubusercontent.com/assets/10472206/12303521/71b79db4-ba33-11e5-8883-becf6d80e376.png)