### PR TITLE
Updates setVersionHeader() to check specific meta

### DIFF
--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -108,7 +108,7 @@ class FilterIfPjax
     protected function setVersionHeader(Response $response, Request $request)
     {
         $crawler = $this->getCrawler($response);
-        $node = $crawler->filter('head > meta[http-equiv]');
+        $node = $crawler->filter('head > meta[http-equiv="X-PJAX-Version"]');
 
         if ($node->count()) {
             $response->header('X-PJAX-Version', $node->attr('content'));


### PR DESCRIPTION
Right now, the meta tag that's being filtered from the request by `setVersionHeader()` is actually all `http-equiv` meta tags.

As I had `<meta http-equiv="X-UA-Compatible" content="IE=edge">` in my project's `<head>`, it kept capturing `IE=edge`.

So with this change instead, it will now look for a specific `<meta http-equiv="X-PJAX-Version" content="foo">` tag, to enable the correct version to be passed on to the response.

If this is accepted, I'll PR the Readme with a cool tip about using Laravel's elixir, to handle force reload automatically.
