### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/css-selector": "^2.7|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*",
+        "phpunit/phpunit" : "^4.8.36",
         "scrutinizer/ocular": "~1.1"
     },
     "autoload": {

--- a/tests/FilterIfPjaxTest.php
+++ b/tests/FilterIfPjaxTest.php
@@ -3,10 +3,11 @@
 namespace Spatie\Pjax\Test;
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Spatie\Pjax\Middleware\FilterIfPjax;
 use Symfony\Component\HttpFoundation\Response;
 
-class FilterIfPjaxTest extends \PHPUnit_Framework_TestCase
+class FilterIfPjaxTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.