### PR TITLE
Version bump to follow latest Laravel dependency range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php" : "^5.5.0|^7.0",
+        "php": "^5.5.0|^7.0",
         "illuminate/support": "^5.1",
         "illuminate/http": "^5.1",
-        "symfony/dom-crawler": "^2.7|^3.0",
-        "symfony/css-selector": "^2.7|^3.0"
+        "symfony/dom-crawler": "^2.7|^3.0|^4.0",
+        "symfony/css-selector": "^2.7|^3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^4.8.36",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.1"
     },
     "autoload": {


### PR DESCRIPTION
Latest Laravel version would not support this package without this update.

```
- Installation request for symfony/css-selector (locked at v4.0.3) -> satisfiable by symfony/css-selector[v4.0.3].
```