### PR TITLE
Fixed Response type

### DIFF
--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -4,7 +4,7 @@ namespace Spatie\Pjax\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\DomCrawler\Crawler;
 
 class FilterIfPjax


### PR DESCRIPTION
Using basic **Symfony\Component\HttpFoundation\Response** instead of inherited **Illuminate\Http\Response** to avoid problems with 3rd party libraries which return responses (JsonResponse, RedirectResponse, ...) inherited directly from **Symfony\Component\HttpFoundation\Response**.