### PR TITLE
Response type fix

### DIFF
--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -4,7 +4,7 @@ namespace Spatie\Pjax\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\DomCrawler\Crawler;
 
 class FilterIfPjax

--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -4,7 +4,8 @@ namespace Spatie\Pjax\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response as BaseResponse;
 use Symfony\Component\DomCrawler\Crawler;
 
 class FilterIfPjax
@@ -12,7 +13,7 @@ class FilterIfPjax
     /** @var \Symfony\Component\DomCrawler\Crawler */
     protected $crawler;
 
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next): BaseResponse
     {
         $response = $next($request);
 


### PR DESCRIPTION
This requires **Illuminate\Http\Response** as input to FilterIfPjax class functions, but allows to return **Symfony\Component\HttpFoundation\Response** by the handle function.
Not perfect, but functional.