### PR TITLE
version 5 support of dom-crawler css-selector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": "^7.2",
         "illuminate/support": "^5.1|^6.0",
         "illuminate/http": "^5.1|^6.0",
-        "symfony/dom-crawler": "^2.7|^3.0|^4.0",
-        "symfony/css-selector": "^2.7|^3.0|^4.0"
+        "symfony/dom-crawler": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.3.5",


### PR DESCRIPTION
Update composer restraint to include version 5.0 of symfony/dom-crawler & symfony/css-selector. All 6 tests pass.  