### PR TITLE
Fix Response constructor

### DIFF
--- a/src/Middleware/FilterIfPjax.php
+++ b/src/Middleware/FilterIfPjax.php
@@ -94,6 +94,6 @@ class FilterIfPjax
     {
         $lowercaseContent = strtolower($response->getContent());
 
-        return Response::create($lowercaseContent);
+        return new Response($lowercaseContent);
     }
 }


### PR DESCRIPTION
The `create` method was removed from `Response` in Symfony 6: https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpFoundation/Response.php#L237